### PR TITLE
RequestInterface in method signature, README for Guzzle 4 and another test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ HTTP Signatures Guzzle 3
 
 [![Build Status](https://travis-ci.org/99designs/http-signatures-guzzle.svg)](https://travis-ci.org/99designs/http-signatures-guzzle)
 
-Adds Guzzle 3 support to [99designs/http-signatures][99signatures]
+Adds [99designs/http-signatures](http-signatures) support to Guzzle 3.  
+For Guzzle 4 see the [99designs/http-signatures-guzzlehttp](99designs/http-signatures-guzzlehttp) repo.
 
 Signing with Guzzle 3
 ---

--- a/src/HttpSignatures/Guzzle/Message.php
+++ b/src/HttpSignatures/Guzzle/Message.php
@@ -2,12 +2,14 @@
 
 namespace HttpSignatures\Guzzle;
 
+use Guzzle\Http\Message\RequestInterface;
+
 class Message
 {
     private $request;
     public $headers;
 
-    public function __construct($request)
+    public function __construct(RequestInterface $request)
     {
         $this->request = $request;
         $this->headers = new MessageHeaders($request);

--- a/src/HttpSignatures/Guzzle/MessageHeaders.php
+++ b/src/HttpSignatures/Guzzle/MessageHeaders.php
@@ -2,11 +2,13 @@
 
 namespace HttpSignatures\Guzzle;
 
+use Guzzle\Http\Message\RequestInterface;
+
 class MessageHeaders
 {
     private $request;
 
-    public function __construct($request)
+    public function __construct(RequestInterface $request)
     {
         $this->request = $request;
     }

--- a/tests/GuzzleSignerTest.php
+++ b/tests/GuzzleSignerTest.php
@@ -8,6 +8,16 @@ use HttpSignatures\Guzzle\Message;
 
 class GuzzleSignerTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * @var \Guzzle\Http\Client
+     */
+    private $client;
+
     public function setUp()
     {
         $this->context = new Context(array(
@@ -31,6 +41,31 @@ class GuzzleSignerTest extends \PHPUnit_Framework_TestCase
                 'algorithm="hmac-sha256"',
                 'headers="(request-target) date"',
                 'signature="SFlytCGpsqb/9qYaKCQklGDvwgmrwfIERFnwt+yqPJw="',
+            )
+        );
+
+        $this->assertEquals(
+            $expectedString,
+            (string) $message->getHeader('Signature')
+        );
+
+        $this->assertEquals(
+            'Signature ' . $expectedString,
+            (string) $message->getHeader('Authorization')
+        );
+    }
+
+    public function testGuzzleRequestHasExpectedHeaders2()
+    {
+        $message = $this->client->get('/path', array('date' => 'today', 'accept' => 'llamas'));
+
+        $expectedString = implode(
+            ',',
+            array(
+                'keyId="pda"',
+                'algorithm="hmac-sha256"',
+                'headers="(request-target) date"',
+                'signature="DAtF133khP05pS5Gh8f+zF/UF7mVUojMj7iJZO3Xk4o="',
             )
         );
 


### PR DESCRIPTION
added reference to http-signatures-httpguzzle repo in the README for Guzzle 4 support.

added another URL without a ?query=string to the tests since that's something that could potentially break.
added RequestInterface requirements to the Message and MessageHeaders constructor.
